### PR TITLE
Sort contours to get smaller on top on example.html

### DIFF
--- a/example/example.html
+++ b/example/example.html
@@ -27,12 +27,23 @@ var c = new Conrec,
     colours = d3.scale.linear().domain([-5, 3]).range(["#fff", "red"]);
 
 c.contour(data, 0, xs.length - 1, 0, ys.length - 1, xs, ys, zs.length, zs);
+// Sort contours by size so small ones get on top
+var contourList = c.contourList()
+    .sort(function(a, b){
+        var extentXA = d3.extent(a.map(function(d){ return d.x; }));
+        var extentYA = d3.extent(a.map(function(d){ return d.y; }));
+        var areaA = (extentXA[1] - extentXA[0]) * (extentYA[1] - extentYA[0]);
+        var extentXB = d3.extent(b.map(function(d){ return d.x; }));
+        var extentYB = d3.extent(b.map(function(d){ return d.y; }));
+        var areaB = (extentXB[1] - extentXB[0]) * (extentYB[1] - extentYB[0]);
+        return areaB - areaA;
+    });
 
 d3.select("body").append("svg")
     .attr("width", width)
     .attr("height", height)
   .selectAll("path")
-    .data(c.contourList())
+    .data(contourList)
   .enter().append("path")
     .style("fill",function(d) { return colours(d.level);})
     .style("stroke","black")


### PR DESCRIPTION
Some of the contours on the example are hidden behind bigger one. So I just added a simple sorting function. It's an ugly hack, but feel free to merge it if you think it's useful.
